### PR TITLE
Include only required app files into docker container

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
-GITEA_ACCESS_TOKEN=abc
-GITEA_HOST_URL=http://localhost:3000
-GIT_REPOSITORY_URL=http://localhost:3000
-TMP_DIR=/tmp
+GITEA_ACCESS_TOKEN=xyz
+GITEA_HOST_URL=http://host.docker.internal:3000
+GIT_REPOSITORY_URL=http://host.docker.internal:3000
+TMP_DIR=/home/runner/app/app-data/tmp
 GITEA_USER=runner
 GITEA_EMAIL=runner@osmforcities.org
+NODE_ENV=development

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,8 @@ COPY ./package.json $HOME/app/
 WORKDIR $HOME/app
 RUN yarn install
 
-COPY ./ $HOME/app/
+# Copy specific application files
+COPY cli $HOME/app/cli/
+COPY config  $HOME/app/config/
+COPY setup.sh  $HOME/app/
+COPY update.sh $HOME/app/ 


### PR DESCRIPTION
The   `COPY ./ $HOME/app/` ,   copy all files from the directory into the container which are not in `.dockerignore` When modifying files unrelated to the processing file application, it's important to consider the impact on the Docker registry. Instead of generating numerous unnecessary images, it would be more efficient to include only the application-specific files. 

cc. @vgeorge 