### PR TITLE
Use less memory

### DIFF
--- a/cli/contexts/cities-of-brazil/actions/setup.js
+++ b/cli/contexts/cities-of-brazil/actions/setup.js
@@ -6,25 +6,14 @@ import { ensureDir } from "fs-extra";
 import logger from "../../../helpers/logger.js";
 import { curlDownload } from "../../../helpers/curl-download.js";
 import { unzip } from "../../../helpers/unzip.js";
-import { getCities } from "../helpers.js";
 import GiteaClient from "../../../helpers/gitea-client.js";
 
 // Context Config
 import {
   CLI_TMP_DIR,
-  CURRENT_DAY_LEVEL_1_DIR,
-  CURRENT_DAY_LEVEL_2_DIR,
-  CURRENT_DAY_LEVEL_3_DIR,
   GIT_ORGANIZATION,
   GIT_REPOSITORY_NAME,
-  OSMIUM_CONFIG_DIR,
-  OSMIUM_CONFIG_LEVEL_1_FILE,
-  OSMIUM_CONFIG_LEVEL_2_DIR,
-  OSMIUM_CONFIG_LEVEL_3_DIR,
   POLYFILES_DIR,
-  POLYFILES_LEVEL_1_DIR,
-  POLYFILES_LEVEL_2_DIR,
-  POLYFILES_LEVEL_3_DIR,
   POLYFILES_URL,
 } from "../config.js";
 
@@ -35,7 +24,6 @@ export const setup = async () => {
   // Initialize directories required by the CLI app
   await ensureDir(CLI_TMP_DIR);
   await ensureDir(POLYFILES_DIR);
-  await ensureDir(OSMIUM_CONFIG_DIR);
 
   // Initialize organization in Gitea
   try {
@@ -90,127 +78,12 @@ export const setup = async () => {
   // Download boundary polygons
   try {
     const POLYFILES_TMP_FILE = path.join(CLI_TMP_DIR, "polyfiles.zip");
+    await fs.remove(POLYFILES_TMP_FILE);
     await curlDownload(POLYFILES_URL, POLYFILES_TMP_FILE);
     await unzip(POLYFILES_TMP_FILE, POLYFILES_DIR);
   } catch (error) {
     logger("Could not download boundary polygons.");
     return;
-  }
-
-  /**
-   * GENERATE LEVEL 1 OSMIUM CONFIG FILES
-   */
-  logger(`Writing Osmium config files for Brazil at ${OSMIUM_CONFIG_DIR}`);
-
-  // Generate config for level 1 boundaries
-  const extracts = (await fs.readdir(POLYFILES_LEVEL_1_DIR))
-    .filter((f) => f.endsWith(".poly"))
-    .map((f) => {
-      const id = f.split(".")[0];
-      return {
-        output: `${id}.osm.pbf`,
-        polygon: {
-          file_name: path.join(POLYFILES_LEVEL_1_DIR, f),
-          file_type: "poly",
-        },
-      };
-    });
-
-  // Write configuration file
-  await fs.writeJSON(
-    OSMIUM_CONFIG_LEVEL_1_FILE,
-    {
-      directory: CURRENT_DAY_LEVEL_1_DIR,
-      extracts,
-    },
-    { spaces: 2 }
-  );
-
-  /**
-   * GENERATE LEVEL 2 OSMIUM CONFIG FILES
-   */
-  const microregioes = (await fs.readdir(POLYFILES_LEVEL_2_DIR))
-    .filter((f) => f.endsWith(".poly"))
-    .reduce((acc, mr) => {
-      const ufId = mr.substr(0, 2);
-      const mrIf = mr.split(".")[0];
-      acc[ufId] = (acc[ufId] || []).concat({
-        output: `${mrIf}.osm.pbf`,
-        polygon: {
-          file_name: path.join(POLYFILES_LEVEL_2_DIR, mr),
-          file_type: "poly",
-        },
-      });
-      return acc;
-    }, {});
-
-  // Create Osmium config files directory
-  await fs.ensureDir(OSMIUM_CONFIG_LEVEL_2_DIR);
-
-  let files = [];
-
-  // For each UF, write conf file
-  const ufs = Object.keys(microregioes);
-  for (let i = 0; i < ufs.length; i++) {
-    const uf = ufs[i];
-
-    const confPath = path.join(OSMIUM_CONFIG_LEVEL_2_DIR, `${uf}.conf`);
-    files.push({
-      confPath,
-      sourcePath: path.join(CURRENT_DAY_LEVEL_1_DIR, `${uf}.osm.pbf`),
-    });
-
-    await fs.writeJSON(
-      confPath,
-      {
-        directory: CURRENT_DAY_LEVEL_2_DIR,
-        extracts: microregioes[uf],
-      },
-      { spaces: 2 }
-    );
-  }
-
-  /**
-   * GENERATE LEVEL 3 OSMIUM CONFIG FILES
-   */
-  const citiesArray = await getCities();
-
-  let citiesConfig = citiesArray.reduce((acc, { municipio, microregion }) => {
-    const mnId = municipio;
-    const mrId = microregion;
-    acc[mrId] = (acc[mrId] || []).concat({
-      output: `${mnId}.osm.pbf`,
-      polygon: {
-        file_name: `${path.join(POLYFILES_LEVEL_3_DIR, mnId)}.poly`,
-        file_type: "poly",
-      },
-    });
-    return acc;
-  }, {});
-
-  // Create Osmium config files directory
-  await fs.ensureDir(OSMIUM_CONFIG_LEVEL_3_DIR);
-
-  // For each microregion, write conf file
-  const citiesIds = Object.keys(citiesConfig);
-  for (let i = 0; i < citiesIds.length; i++) {
-    const cityId = citiesIds[i];
-
-    const confPath = path.join(OSMIUM_CONFIG_LEVEL_3_DIR, `${cityId}.conf`);
-
-    files.push({
-      confPath,
-      sourcePath: path.join(CURRENT_DAY_LEVEL_2_DIR, `${cityId}.osm.pbf`),
-    });
-
-    await fs.writeJSON(
-      confPath,
-      {
-        directory: CURRENT_DAY_LEVEL_3_DIR,
-        extracts: citiesConfig[cityId],
-      },
-      { spaces: 2 }
-    );
   }
 };
 

--- a/cli/contexts/cities-of-brazil/config.js
+++ b/cli/contexts/cities-of-brazil/config.js
@@ -35,6 +35,11 @@ export const CLI_GIT_DIR = path.join(CLI_DATA_DIR, "git");
 export const POLYFILES_URL =
   "https://www.dropbox.com/s/nvutp2fcg75fcc6/polyfiles.zip?dl=0";
 export const POLYFILES_DIR = path.join(CLI_DATA_DIR, "polyfiles");
+export const POLYFILES_LEVEL_0_DIR = path.join(
+  POLYFILES_DIR,
+  "polyfiles",
+  "br"
+);
 export const POLYFILES_LEVEL_1_DIR = path.join(
   POLYFILES_DIR,
   "polyfiles",
@@ -59,6 +64,10 @@ export const CURRENT_DAY_DIR = path.join(CLI_TMP_DIR, "current-day");
 export const CURRENT_DAY_FILE = path.join(
   CURRENT_DAY_DIR,
   "current-day.osm.pbf"
+);
+export const CURRENT_DAY_COUNTRY_FILE = path.join(
+  CURRENT_DAY_DIR,
+  "current-day-country.osm.pbf"
 );
 export const CURRENT_DAY_LEVEL_1_DIR = path.join(CURRENT_DAY_DIR, "level-1");
 export const CURRENT_DAY_LEVEL_2_DIR = path.join(CURRENT_DAY_DIR, "level-2");

--- a/cli/contexts/cities-of-brazil/config.js
+++ b/cli/contexts/cities-of-brazil/config.js
@@ -10,6 +10,8 @@ import {
   TMP_DIR,
 } from "../../../config/index.js";
 
+const CONTEXT_NAME = "cities-of-brazil";
+
 // Target organization and repository
 export const GIT_ORGANIZATION = "cities-of";
 export const GIT_REPOSITORY_NAME = "brazil";
@@ -22,42 +24,19 @@ repositoryUrl.pathname = `/${GIT_ORGANIZATION}/${GIT_REPOSITORY_NAME}`;
 export const GIT_REPOSITORY_URL = repositoryUrl.toString();
 
 // CLI directories
-export const CONTEXT_APP_DIR = path.join(
-  CLI_APP_DIR,
-  "contexts",
-  "cities-of-brazil"
-);
-export const CLI_TMP_DIR = path.join(TMP_DIR, "contexts", "brazil");
-const CLI_DATA_DIR = path.join(CONTEXTS_DATA_PATH, "brazil");
+export const CONTEXT_APP_DIR = path.join(CLI_APP_DIR, "contexts", CONTEXT_NAME);
+export const CLI_TMP_DIR = path.join(TMP_DIR, "contexts", CONTEXT_NAME);
+const CLI_DATA_DIR = path.join(CONTEXTS_DATA_PATH, CONTEXT_NAME);
 export const CLI_GIT_DIR = path.join(CLI_DATA_DIR, "git");
 
 // Polyfiles
 export const POLYFILES_URL =
-  "https://www.dropbox.com/s/nvutp2fcg75fcc6/polyfiles.zip?dl=0";
+  "https://www.dropbox.com/s/vb9j073ol3ty6ev/polyfiles.zip?dl=0";
 export const POLYFILES_DIR = path.join(CLI_DATA_DIR, "polyfiles");
-export const POLYFILES_LEVEL_0_DIR = path.join(
-  POLYFILES_DIR,
-  "polyfiles",
-  "br"
-);
-export const POLYFILES_LEVEL_1_DIR = path.join(
-  POLYFILES_DIR,
-  "polyfiles",
-  "br",
-  "ufs"
-);
-export const POLYFILES_LEVEL_2_DIR = path.join(
-  POLYFILES_DIR,
-  "polyfiles",
-  "br",
-  "microregions"
-);
-export const POLYFILES_LEVEL_3_DIR = path.join(
-  POLYFILES_DIR,
-  "polyfiles",
-  "br",
-  "municipalities"
-);
+export const POLYFILES_LEVEL_0_DIR = path.join(POLYFILES_DIR);
+export const POLYFILES_LEVEL_1_DIR = path.join(POLYFILES_DIR, "ufs");
+export const POLYFILES_LEVEL_2_DIR = path.join(POLYFILES_DIR, "microregions");
+export const POLYFILES_LEVEL_3_DIR = path.join(POLYFILES_DIR, "municipalities");
 
 // Day extract file
 export const CURRENT_DAY_DIR = path.join(CLI_TMP_DIR, "current-day");
@@ -73,18 +52,3 @@ export const CURRENT_DAY_LEVEL_1_DIR = path.join(CURRENT_DAY_DIR, "level-1");
 export const CURRENT_DAY_LEVEL_2_DIR = path.join(CURRENT_DAY_DIR, "level-2");
 export const CURRENT_DAY_LEVEL_3_DIR = path.join(CURRENT_DAY_DIR, "level-3");
 export const CURRENT_DAY_PRESETS_DIR = path.join(CURRENT_DAY_DIR, "presets");
-
-// Osmium config files
-export const OSMIUM_CONFIG_DIR = path.join(CLI_DATA_DIR, "osmium-config");
-export const OSMIUM_CONFIG_LEVEL_1_FILE = path.join(
-  OSMIUM_CONFIG_DIR,
-  "level-1.conf"
-);
-export const OSMIUM_CONFIG_LEVEL_2_DIR = path.join(
-  OSMIUM_CONFIG_DIR,
-  "level-2"
-);
-export const OSMIUM_CONFIG_LEVEL_3_DIR = path.join(
-  OSMIUM_CONFIG_DIR,
-  "level-3"
-);

--- a/cli/helpers/osmium.js
+++ b/cli/helpers/osmium.js
@@ -37,6 +37,24 @@ export async function extract(configFile, currentDayFile) {
 }
 
 /**
+ * Extracts a file by a polyfile.
+ *
+ * @param {string} polyfilePath File path to polyfile file
+ * @param {string} currentDayFile File path to current day file
+ */
+export async function extractPoly(polyfilePath, source, target) {
+  await execaToStdout(`osmium`, [
+    `extract`,
+    `-p`,
+    polyfilePath,
+    source,
+    `-o`,
+    target,
+    `--overwrite`,
+  ]);
+}
+
+/**
  * Executes osmium tags-filter command.
  *
  * @param {string} inputFile File path to input file


### PR DESCRIPTION
Using osmium configuration files to process multiple areas at the same time has let to excessive memory consumption. I changed the approach to process the areas pbf files in series, from country level (level 0) to cities level (level 3). In my tests this reduced the memory considerably without affecting processing time very much.

Summary of changes:

- Drop processing PBF files in parallel
- Add level 0 area (brazil.polyfile) to help reducing memory usage
- Update link to files stored in Dropbox

How to test:

- Delete cities-of-brazil remote repository
- Delete local git repository in temp dir
- Run ` yarn cli context cities-of-brazil setup` 
- Run ` yarn cli context cities-of-brazil update`

@Rub21 ready for review.