### PR TITLE
Separate CLI data paths by environment

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -10,6 +10,22 @@ const basePath = path.resolve();
 export const CLI_APP_DIR = path.join(basePath, "cli");
 
 /**
+ * Path to the data directory used by the CLI to store data
+ * (e.g. downloaded files, local git repository, etc)
+ *
+ * The path can be set via environment variable CLI_DATA_DIR.
+ * If not set, the default value depends on the environment:
+ *  - In development: The default value is set to "app-data/development"
+ *  - In production: The default value is set to "app-data/production"
+ *  - Other environments: The default value is set to the value of NODE_ENV
+ *
+ */
+const CLI_DATA_DIR = path.join(
+  process.env.CLI_DATA_DIR || path.join(basePath, "app-data", "cli"),
+  process.env.NODE_ENV ? `${process.env.NODE_ENV}` : "development"
+);
+
+/**
  * The default date for the start of the git history, which can be set via
  * environment variable. If not set, the default value depends on the
  * environment:
@@ -47,19 +63,29 @@ export const getPresets = async () =>
   await loadCsv(path.join(basePath, "config", "presets.csv"));
 
 /**
- * DATA PATHS
+ * TEMPORARY DIRECTORY
+ *
+ * Used to store temporary files during the execution of
+ * the CLI. The path can be set via environment variable TMP_DIR. If not set,
+ * the default value is /tmp/osm-for-cities.
  */
-
 export const TMP_DIR =
-  process.env.TMP_DIR || path.join("/", "tmp", "osm-git-history");
-export const CONTEXTS_DATA_PATH =
-  process.env.OFC_CONTEXTS_DATA_PATH || path.join(basePath, "app-data", "cli");
+  process.env.TMP_DIR || path.join("/", "tmp", "osm-for-cities");
 
 /**
- * HISTORY PBF
+ * CONTEXTS DATA PATH
+ * Path to the contexts data directory used by the CLI.
+ */
+export const CONTEXTS_DATA_PATH = path.join(CLI_DATA_DIR, "contexts");
+
+/**
+ * HISTORY PBF PATH
+ * Path to the history pbf data directory used by the CLI, can be set via
+ * environment variable HISTORY_PBF_PATH. If not set, the default value is
+ * $CLI_DATA_DIR/history-pbf.
  */
 export const HISTORY_PBF_PATH =
-  process.env.HISTORY_PBF_PATH || path.join(CONTEXTS_DATA_PATH, "history-pbf");
+  process.env.HISTORY_PBF_PATH || path.join(CLI_DATA_DIR, "history-pbf");
 
 export const PRESETS_HISTORY_PBF_FILE = path.join(
   HISTORY_PBF_PATH,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,8 @@ services:
     networks:
       - gitea
     volumes:
-      - ./app-data/docker/gitea/data:/data
-      - ./app-data/docker/gitea/ssh:/data/git/.ssh
+      - ./app-data/gitea/data:/data
+      - ./app-data/gitea/ssh:/data/git/.ssh
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
     ports:
@@ -23,8 +23,8 @@ services:
   runner_setup:
     image: developmentseed/osm-for-cities-runner:v1
     build:
-          context: ./
-          dockerfile: Dockerfile
+      context: ./
+      dockerfile: Dockerfile
     volumes:
       - ./app-data:/home/runner/app/app-data
       # - ./:/home/runner/app


### PR DESCRIPTION
Contributes to #21. 

To test, run `yarn cli fetch-full-history` and `NODE_ENV=production yarn cli fetch-full-history`, and then inspect `app-data` dir.

@Rub21 ready for review.