### PR TITLE
Update values in ENV VARS and  update cli in cronjob/docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,3 @@ RUN yarn install
 # Copy specific application files
 COPY cli $HOME/app/cli/
 COPY config  $HOME/app/config/
-COPY setup.sh  $HOME/app/
-COPY update.sh $HOME/app/ 

--- a/config/index.js
+++ b/config/index.js
@@ -36,7 +36,7 @@ const CLI_DATA_DIR = path.join(
  */
 export const GIT_HISTORY_START_DATE =
   process.env.GIT_HISTORY_START_DATE ||
-  (NODE_ENV !== "development"
+  (NODE_ENV === "development"
     ? "2010-01-01Z"
     : format(subDays(new Date(), 10), "yyyy-MM-dd") + "Z");
 
@@ -55,8 +55,8 @@ export const GITEA_HOST_URL =
  */
 export const FULL_HISTORY_FILE_URL =
   NODE_ENV === "development"
-    ? "https://planet.osm.org/pbf/full-history/history-latest.osm.pbf"
-    : "https://www.dropbox.com/s/j6c71o5jll8f067/brazil-history-2010-01.osh.pbf?dl=0";
+    ? "https://www.dropbox.com/s/j6c71o5jll8f067/brazil-history-2010-01.osh.pbf?dl=0"
+    : "https://planet.osm.org/pbf/full-history/history-latest.osm.pbf";
 
 /**
  * OSM PRESETS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,14 @@ services:
     volumes:
       - ./app-data:/home/runner/app/app-data
       # - ./:/home/runner/app
-    command: "/home/runner/app/setup.sh"
+    command: >
+      /bin/bash -c "
+        echo 'Start setting up...';
+        yarn cli fetch-full-history
+        yarn cli context cities-of-brazil reset-git-local
+        yarn cli context cities-of-brazil reset-git-remote
+        yarn cli context cities-of-brazil setup
+      "
     env_file:
       - ./.env
   runner_update:
@@ -41,6 +48,13 @@ services:
     volumes:
       - ./app-data:/home/runner/app/app-data
       # - ./:/home/runner/app
-    command: "/home/runner/app/update.sh"
+    command: >
+      /bin/bash -c "
+        echo 'Start updating...';
+        if [ "$NODE_ENV" = "production" ]; then
+            yarn cli update-presets-history --recursive
+        fi
+        yarn cli context cities-of-brazil update --recursive
+      "
     env_file:
       - ./.env

--- a/osm-for-cities/Chart.yaml
+++ b/osm-for-cities/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0-0.dev.git.182.hbab7a65
+version: 0.1.0-0.dev.git.208.hb2c1b15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/osm-for-cities/templates/runner/cronjob-setup.yml
+++ b/osm-for-cities/templates/runner/cronjob-setup.yml
@@ -29,7 +29,7 @@ spec:
                 - -c
                 - |
                   echo 'Start setting up...';
-                  # yarn cli fetch-full-history
+                  yarn cli fetch-full-history
                   yarn cli context cities-of-brazil reset-git-local
                   yarn cli context cities-of-brazil reset-git-remote
                   yarn cli context cities-of-brazil setup

--- a/setup.sh
+++ b/setup.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -x
-echo 'Start setting up...'
-# Remove folder to reset
-rm -rf /home/runner/app/app-data/*
-yarn cli fetch-full-history
-yarn cli update-presets-history --recursive
-yarn cli context cities-of-brazil setup

--- a/update.sh
+++ b/update.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -x
-echo 'Start updating...'
-if [ -f "${TMP_DIR}/history-latest.osh.pbf" ]; then
-    yarn cli update-presets-history --recursive
-    yarn cli context cities-of-brazil update
-fi


### PR DESCRIPTION
- Previously, when we set the NODE_ENV variable to "develop", it would download the entire history. However, I made some improvements, and now it only fetches the necessary data from Dropbox.
- Additionally, I have decided to remove the setup.sh and update.sh files. This is because we typically handle the CLI setup in the deployment and docker-compose files, in the command section.
cc. @vgeorge 