### PR TITLE
Fix update-presets-history invocation

### DIFF
--- a/cli/update-presets-history.js
+++ b/cli/update-presets-history.js
@@ -139,7 +139,7 @@ export async function updatePresetsHistory(options) {
 
     if (options && options.recursive) {
       logger("Replicating history file...");
-      await updatePresetsHistory();
+      await updatePresetsHistory(options);
     }
   } catch (error) {
     logger(error);


### PR DESCRIPTION
The recursion is not working correctly for `update-presets-history` task because the CLI options are not being passed to the next invocation of the function `updatePresetsHistory()`. This is causing the recursion not to be executed more than two days.

@Rub21 ready for review. 
