### PR TITLE
Apply env to custom TMP path

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -72,7 +72,8 @@ export const getPresets = async () =>
  * the default value is /tmp/osm-for-cities.
  */
 export const TMP_DIR =
-  process.env.TMP_DIR || path.join("/", "tmp", "osm-for-cities", NODE_ENV);
+  path.join(process.env.TMP_DIR, NODE_ENV) ||
+  path.join("/", "tmp", "osm-for-cities", NODE_ENV);
 
 /**
  * CONTEXTS DATA PATH

--- a/config/index.js
+++ b/config/index.js
@@ -71,9 +71,10 @@ export const getPresets = async () =>
  * the CLI. The path can be set via environment variable TMP_DIR. If not set,
  * the default value is /tmp/osm-for-cities.
  */
-export const TMP_DIR =
-  path.join(process.env.TMP_DIR, NODE_ENV) ||
-  path.join("/", "tmp", "osm-for-cities", NODE_ENV);
+export const TMP_DIR = path.join(
+  process.env.TMP_DIR || path.join("/", "tmp", "osm-for-cities"),
+  NODE_ENV
+);
 
 /**
  * CONTEXTS DATA PATH


### PR DESCRIPTION
In #27 we added environment folders to the working directory to separate environments using the same volume, but we forgot to apply them to custom TMP_DIR env var.

@Rub21 this should fix the issue you reported via chat.