### PR TITLE
Reset local git before running 'update' task

### DIFF
--- a/cli/contexts/cities-of-brazil/config.js
+++ b/cli/contexts/cities-of-brazil/config.js
@@ -20,7 +20,7 @@ export const GIT_REPOSITORY_NAME = "brazil";
 const repositoryUrl = new URL(GITEA_HOST_URL);
 repositoryUrl.username = GITEA_USER;
 repositoryUrl.password = GITEA_ACCESS_TOKEN;
-repositoryUrl.pathname = `/${GIT_ORGANIZATION}/${GIT_REPOSITORY_NAME}`;
+repositoryUrl.pathname = `/${GIT_ORGANIZATION}/${GIT_REPOSITORY_NAME}.git`;
 export const GIT_REPOSITORY_URL = repositoryUrl.toString();
 
 // CLI directories


### PR DESCRIPTION
With this change, the local repository always be cleared and synced with the remote before the `update` task is executed. This avoids getting to a state where the local repository is out of sync with the remote, causing the workflow to break. This might help to fix #37.

cc @Rub21 ready for review.