### PR TITLE
Fix date ranges

### DIFF
--- a/cli/contexts/cities-of-brazil/actions/reset-git-remote.js
+++ b/cli/contexts/cities-of-brazil/actions/reset-git-remote.js
@@ -3,6 +3,7 @@ import GiteaClient from "../../../helpers/gitea-client.js";
 
 // Context config
 import { GIT_ORGANIZATION, GIT_REPOSITORY_NAME } from "../config.js";
+import { initRemoteGit } from "./setup.js";
 
 // Create Gitea client
 const giteaClient = new GiteaClient();
@@ -16,7 +17,8 @@ export const resetRemoteGit = async () => {
 
     switch (status) {
       case 204:
-        logger(`Remote git repository was deleted.`);
+        await initRemoteGit();
+        logger(`Remote git repository was reset.`);
         break;
 
       case 404:

--- a/cli/fetch-full-history.js
+++ b/cli/fetch-full-history.js
@@ -5,10 +5,12 @@ import {
   FULL_HISTORY_FILE_URL,
   getPresets,
   PRESETS_HISTORY_PBF_FILE,
+  PRESETS_HISTORY_META_JSON,
 } from "../config/index.js";
-import { ensureDir } from "fs-extra";
+import { ensureDir, remove } from "fs-extra";
 import * as path from "path";
 import { curlDownload } from "./helpers/curl-download.js";
+import { updatePresetsHistoryMetafile } from "./update-presets-history.js";
 
 // Local constants
 
@@ -27,6 +29,8 @@ const PRESET_HISTORY_PBF_TMP_FILE = path.join(
 export async function fetchFullHistory() {
   await ensureDir(TMP_DIR);
   await ensureDir(HISTORY_PBF_PATH);
+
+  await remove(FULL_HISTORY_TMP_FILE);
 
   // Download latest history file to local volume with curl
   await curlDownload(FULL_HISTORY_FILE_URL, FULL_HISTORY_TMP_FILE);
@@ -50,4 +54,8 @@ export async function fetchFullHistory() {
     PRESET_HISTORY_PBF_TMP_FILE,
     PRESETS_HISTORY_PBF_FILE,
   ]);
+
+  await remove(PRESETS_HISTORY_META_JSON);
+
+  await updatePresetsHistoryMetafile();
 }

--- a/cli/update-presets-history.js
+++ b/cli/update-presets-history.js
@@ -1,18 +1,72 @@
 import fs, { ensureDir } from "fs-extra";
-// import { HISTORY_PBF_PATH, latestHistoryFilePath } from "../../config/index.js";
 import * as path from "path";
-import { addDays, differenceInCalendarDays, parseISO, subDays } from "date-fns";
+import {
+  addDays,
+  differenceInCalendarDays,
+  endOfDay,
+  parseISO,
+  subDays,
+} from "date-fns";
 import logger, { time, timeEnd } from "./helpers/logger.js";
-import { PRESETS_HISTORY_PBF_FILE, TMP_DIR } from "../config/index.js";
+import {
+  PRESETS_HISTORY_META_JSON,
+  PRESETS_HISTORY_PBF_FILE,
+  TMP_DIR,
+} from "../config/index.js";
 import { execaToStdout } from "./helpers/execa.js";
 import { curlDownload } from "./helpers/curl-download.js";
 import execa from "execa";
 
-const PRESETS_HISTORY_META_JSON = `${PRESETS_HISTORY_PBF_FILE}.json`;
-
 const TMP_HISTORY_DIR = path.join(TMP_DIR, "history");
 
-const fistDailyChangefileTimestamp = parseISO("2012-09-13T00:00:00Z");
+// This is the date of first daily changefile available on OpenStreetMap
+const fistDailyChangefileTimestamp = parseISO("2012-09-12T23:59:59.999Z");
+
+export async function updatePresetsHistoryMetafile(extraMeta = {}) {
+  logger("Updating history file timestamp in meta JSON file...");
+
+  let historyMeta = {};
+
+  // Load meta JSON file if it exists
+  if (await fs.pathExists(PRESETS_HISTORY_META_JSON)) {
+    historyMeta = await fs.readJson(PRESETS_HISTORY_META_JSON);
+  }
+
+  time("Duration of timestamp update");
+
+  // Extract metadata from history file
+  const { stdout: firstTimestamp } = await execaToStdout("osmium", [
+    "fileinfo",
+    "-e",
+    "-g",
+    "data.timestamp.first",
+    PRESETS_HISTORY_PBF_FILE,
+  ]);
+
+  const { stdout: lastTimestamp } = await execaToStdout("osmium", [
+    "fileinfo",
+    "-e",
+    "-g",
+    "data.timestamp.last",
+    PRESETS_HISTORY_PBF_FILE,
+  ]);
+
+  // Write timestamp to meta JSON file
+  await fs.writeJSON(
+    PRESETS_HISTORY_META_JSON,
+    {
+      ...historyMeta,
+      elements: {
+        firstTimestamp,
+        lastTimestamp,
+      },
+      ...extraMeta,
+    },
+    { spaces: 2 }
+  );
+
+  timeEnd("Duration of timestamp update");
+}
 
 export async function updatePresetsHistory(options) {
   try {
@@ -26,78 +80,62 @@ export async function updatePresetsHistory(options) {
 
     // Get timestamp from history file and update meta
     if (!(await fs.pathExists(PRESETS_HISTORY_META_JSON))) {
-      logger("Updating history file timestamp in meta JSON file...");
-
-      time("Duration of timestamp update");
-
-      // Extract metadata from history file
-      const { stdout } = await execaToStdout("osmium", [
-        "fileinfo",
-        "-e",
-        "-g",
-        "data.timestamp.last",
-        PRESETS_HISTORY_PBF_FILE,
-      ]);
-
-      // Write timestamp to meta JSON file
-      await fs.writeJSON(PRESETS_HISTORY_META_JSON, {
-        timestamp: parseISO(stdout),
-      });
-      timeEnd("Duration of timestamp update");
+      await updatePresetsHistoryMetafile();
     }
 
     const historyFileMeta = await fs.readJSON(PRESETS_HISTORY_META_JSON);
-    let historyFileTimestamp = parseISO(historyFileMeta.timestamp);
+
+    let lastDailyUpdate = endOfDay(
+      parseISO(`${historyFileMeta.elements.lastTimestamp.slice(0, 10)}Z`)
+    );
 
     const historyFileAgeInDays = differenceInCalendarDays(
       Date.now(),
-      historyFileTimestamp
+      lastDailyUpdate
     );
 
-    if (historyFileAgeInDays < 1) {
+    if (historyFileAgeInDays <= 1) {
       logger("History file is updated.");
       return;
     }
 
     // Check if history file is older than the fist daily changefile
-    if (
-      historyFileTimestamp.getTime() < fistDailyChangefileTimestamp.getTime()
-    ) {
+    if (lastDailyUpdate.getTime() < fistDailyChangefileTimestamp.getTime()) {
       logger(
         `History file is older than ${fistDailyChangefileTimestamp.toISOString()}, applying the first daily diff available.`
       );
 
       // Pretend the history file timestamp is from the day before the fist daily changefile
-      historyFileTimestamp = subDays(fistDailyChangefileTimestamp, 1);
+      lastDailyUpdate = subDays(fistDailyChangefileTimestamp, 1);
     }
 
+    const nextDay = addDays(lastDailyUpdate, 1);
+
     // Calculate next day sequence number from current timestamp
-    const nextDaySequenceNumber = (
-      differenceInCalendarDays(
-        historyFileTimestamp,
-        fistDailyChangefileTimestamp
-      ) + 2
+    const nextDayChangeFileNumber = (
+      differenceInCalendarDays(nextDay, fistDailyChangefileTimestamp) + 1
     )
       .toString()
       .padStart(9, "0");
 
     const dailyChangeFile = path.join(
       TMP_HISTORY_DIR,
-      `${nextDaySequenceNumber}.osc.gz`
+      `${nextDayChangeFileNumber}.osc.gz`
     );
 
-    logger(`Downloading day changefile ${nextDaySequenceNumber}...`);
+    logger(`Downloading day changefile ${nextDayChangeFileNumber}...`);
 
     // Download daily changefile
     try {
       time("Duration of daily changefile download");
       await curlDownload(
-        `https://planet.osm.org/replication/day/${nextDaySequenceNumber.slice(
+        `https://planet.osm.org/replication/day/${nextDayChangeFileNumber.slice(
           0,
           3
-        )}/${nextDaySequenceNumber.slice(3, 6)}/${nextDaySequenceNumber.slice(
+        )}/${nextDayChangeFileNumber.slice(
+          3,
           6
-        )}.osc.gz`,
+        )}/${nextDayChangeFileNumber.slice(6)}.osc.gz`,
         dailyChangeFile
       );
       timeEnd("Duration of daily changefile download");
@@ -127,10 +165,7 @@ export async function updatePresetsHistory(options) {
       overwrite: true,
     });
 
-    // Write timestamp to meta JSON file
-    await fs.writeJSON(PRESETS_HISTORY_META_JSON, {
-      timestamp: addDays(historyFileTimestamp, 1).toISOString(),
-    });
+    await updatePresetsHistoryMetafile();
     logger(`Finished!`);
 
     await fs.remove(dailyChangeFile);

--- a/config/index.js
+++ b/config/index.js
@@ -29,16 +29,19 @@ const CLI_DATA_DIR = path.join(
 
 /**
  * The default date for the start of the git history, which can be set via
- * environment variable. If not set, the default value depends on the
- * environment:
- *   - In development: The default value is set to "2010-01-01Z".
- *   - In production: The default value is set to 30 days from the current date.
+ * environment variable.
  */
 export const GIT_HISTORY_START_DATE =
   process.env.GIT_HISTORY_START_DATE ||
   (NODE_ENV === "development"
-    ? "2010-01-01Z"
+    ? "2015-02-25Z"
     : format(subDays(new Date(), 10), "yyyy-MM-dd") + "Z");
+
+export const GIT_HISTORY_END_DATE =
+  process.env.GIT_HISTORY_END_DATE ||
+  (NODE_ENV === "development"
+    ? "2015-03-05Z"
+    : format(new Date(), "yyyy-MM-dd") + "Z");
 
 /**
  * GITEA SERVER
@@ -100,3 +103,4 @@ export const PRESETS_HISTORY_PBF_FILE = path.join(
   HISTORY_PBF_PATH,
   "presets-history.osh.pbf"
 );
+export const PRESETS_HISTORY_META_JSON = `${PRESETS_HISTORY_PBF_FILE}.json`;

--- a/config/index.js
+++ b/config/index.js
@@ -52,10 +52,15 @@ export const GITEA_HOST_URL =
 
 /**
  * HISTORY PBF URL
+ *
+ * The sample was generate with the following commands:
+ *
+ * osmium time-filter -o ofc-sample.osh.pbf presets-history.osh.pbf 2015-05-01T00:00:00Z 2015-05-05T00:00:00Z
+ * osmium extract --bbox -77,-34,-28,9 -H ofc-sample.osh.pbf -o sao-paulo-2015-05-01-2015-05-05.osh.pbf
  */
 export const FULL_HISTORY_FILE_URL =
   NODE_ENV === "development"
-    ? "https://www.dropbox.com/s/j6c71o5jll8f067/brazil-history-2010-01.osh.pbf?dl=0"
+    ? "https://www.dropbox.com/s/piqs9gjsre1gg6b/sao-paulo-2015-05-01-2015-05-05.osh.pbf?dl=0"
     : "https://planet.osm.org/pbf/full-history/history-latest.osm.pbf";
 
 /**

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "A platform for distributing OpenStreetMap data presets for cities",
   "scripts": {
-    "cli": "node cli/index.js",
+    "cli": "TZ=UTC node cli/index.js",
     "lint": "eslint cli"
   },
   "author": "Vitor George <vitor.george@gmail.com>",


### PR DESCRIPTION
Fix #39. Changes added:

- Add TZ=UTC environment variable to enforce UTC dates in the runner
- Changed the history file sample  for development
- Task 'reset-git-remote’ resets the remote repository, instead of just deleting it
- Several date-related fixes on fetch-full-history, update-presets-history and context update tasks

In order to review, make sure your `.env` file is set to use the local gitea server.

## Test scenario 1: repository is empty, initial date is not available before first available day in history

- Run `yarn cli context cities-of-brazil reset-git-remote`
- Run `yarn cli fetch-full-history`
- `/tmp/osm-for-cities/cli/development/history-pbf/presets-history.osh.pbf.json` should contain first and last timestamps of the elements included in the history file
- Add `GIT_HISTORY_START_DATE=2007-01-01T23:59:59.999Z` to your `.env` file 
- Run `yarn cli context cities-of-brazil update --recursive` 
- The repository is populated from `2008-09-15`, which is the first day available in the history file
- Stop the runner

## Test scenario 2: do not push any updates if desired date is not available in the history file

- Run `yarn cli context cities-of-brazil reset-git-remote`
- Run `yarn cli fetch-full-history`
- Add `GIT_HISTORY_START_DATE=2022-01-01T23:59:59.999Z` to your `.env` file 
- Run `yarn cli context cities-of-brazil update --recursive` 
- No updates are pushed to the repository

## Test scenario 3: push updates only to the latest day available in the history file

- Run `yarn cli context cities-of-brazil reset-git-remote`
- Run `yarn cli fetch-full-history`
- Add `GIT_HISTORY_START_DATE=2015-02-24T23:59:59.999Z` to your `.env` file 
- Run `yarn cli context cities-of-brazil update --recursive` 
- On finish, the repository should include updates up to `2015-02-27`, which is the last day available in the history file

## Test scenario 4: update-presets-history stop at the last day available at OSM planet server

- Run `yarn cli context cities-of-brazil reset-git-remote`
- Run `yarn cli fetch-full-history`
- Edit last history timestamp to a very recent date in `/tmp/osm-for-cities/cli/development/history-pbf/presets-history.osh.pbf.json` file, like in this example:

```json
     {
      "elements": {
        "firstTimestamp": "2008-09-15T16:30:28Z",
        "lastTimestamp": "2023-06-25T18:11:58Z"
      }
    }
```

- Run `yarn cli update-presets-history --recursive` 
- The task will stop at the last day available in the [replication server](https://planet.osm.org/replication/day/), which should be yesterday
- Add a very recent date (2 days ago, for e.g.) to your .env file, like: `GIT_HISTORY_START_DATE=2023-06-26T23:59:59.999Z`
- Run `yarn cli context cities-of-brazil update --recursive` 
- On finish, the repository should include updates from `GIT_HISTORY_START_DATE` to yesterday

@Rub21 this is ready for review.