### PR TITLE
Enhance logs

### DIFF
--- a/cli/contexts/cities-of-brazil/actions/reset-git-local.js
+++ b/cli/contexts/cities-of-brazil/actions/reset-git-local.js
@@ -1,14 +1,14 @@
 import fs from "fs-extra";
 import { CLI_GIT_DIR } from "../config.js";
-import logger from "../../../helpers/logger.js";
+import { logger } from "../../../helpers/logger.js";
 
 // Reset local git repository
 export const resetLocalGit = async () => {
   if (await fs.pathExists(CLI_GIT_DIR)) {
     await fs.remove(CLI_GIT_DIR);
-    logger(`Local git repository at ${CLI_GIT_DIR} was removed.`);
+    logger.info(`Local git repository at ${CLI_GIT_DIR} was removed.`);
   } else {
-    logger(`Local git repository is not initialized, nothing to reset.`);
+    logger.info(`Local git repository is not initialized, nothing to reset.`);
   }
 };
 

--- a/cli/contexts/cities-of-brazil/actions/reset-git-remote.js
+++ b/cli/contexts/cities-of-brazil/actions/reset-git-remote.js
@@ -1,4 +1,4 @@
-import logger from "../../../helpers/logger.js";
+import { logger } from "../../../helpers/logger.js";
 import GiteaClient from "../../../helpers/gitea-client.js";
 
 // Context config
@@ -18,23 +18,23 @@ export const resetRemoteGit = async () => {
     switch (status) {
       case 204:
         await initRemoteGit();
-        logger(`Remote git repository was reset.`);
+        logger.info(`Remote git repository was reset.`);
         break;
 
       case 404:
-        logger(
+        logger.error(
           `Remote git repository was not found, is your Gitea token correct?`
         );
         break;
 
       default:
-        logger(
+        logger.error(
           `Unexpected ${status} status while deleting remote git repository.`
         );
         break;
     }
   } catch (error) {
-    logger(error);
+    logger.error(error);
     return;
   }
 };

--- a/cli/contexts/cities-of-brazil/actions/setup.js
+++ b/cli/contexts/cities-of-brazil/actions/setup.js
@@ -3,7 +3,7 @@ import fs from "fs-extra";
 import { ensureDir } from "fs-extra";
 
 // Helpers
-import logger from "../../../helpers/logger.js";
+import { logger } from "../../../helpers/logger.js";
 import { curlDownload } from "../../../helpers/curl-download.js";
 import { unzip } from "../../../helpers/unzip.js";
 import GiteaClient from "../../../helpers/gitea-client.js";
@@ -40,10 +40,12 @@ export async function initRemoteGit() {
         throw "Could not create repository.";
       }
     } else {
-      logger(`Repository '${GIT_ORGANIZATION}/${GIT_REPOSITORY_NAME}' exists.`);
+      logger.info(
+        `Repository '${GIT_ORGANIZATION}/${GIT_REPOSITORY_NAME}' exists.`
+      );
     }
   } catch (error) {
-    logger(error);
+    logger.error(error);
     return;
   }
 }
@@ -70,10 +72,10 @@ export const setup = async () => {
         throw "Could not create organization.";
       }
     } else {
-      logger(`Organization '${GIT_ORGANIZATION}' exists.`);
+      logger.info(`Organization '${GIT_ORGANIZATION}' exists.`);
     }
   } catch (error) {
-    logger(error);
+    logger.error(error);
     return;
   }
 
@@ -86,7 +88,7 @@ export const setup = async () => {
     await curlDownload(POLYFILES_URL, POLYFILES_TMP_FILE);
     await unzip(POLYFILES_TMP_FILE, POLYFILES_DIR);
   } catch (error) {
-    logger("Could not download boundary polygons.");
+    logger.error("Could not download boundary polygons.");
     return;
   }
 };

--- a/cli/contexts/cities-of-brazil/actions/update.js
+++ b/cli/contexts/cities-of-brazil/actions/update.js
@@ -15,7 +15,7 @@ import pLimit from "p-limit";
 import execa from "execa";
 
 // Helpers
-import logger from "../../../helpers/logger.js";
+import { logger } from "../../../helpers/logger.js";
 import {
   extractPoly,
   tagsFilter,
@@ -110,7 +110,7 @@ export const update = async (options) => {
     // the first history timestamp as start date
     currentDailyUpdate = endOfDay(firstHistoryTimestamp);
   } else if (isAfter(currentDailyUpdate, endOfDay(lastHistoryTimestamp))) {
-    logger(
+    logger.info(
       `The history file doesn't include ${currentDailyUpdate.toISOString()}, nothing to update.`
     );
     return;
@@ -123,15 +123,15 @@ export const update = async (options) => {
     .concat("Z");
 
   // Extract OSM data from history file at the current date
-  logger(`Filtering: ${currentDayISO}`);
+  logger.info(`Filtering: ${currentDayISO}`);
   await timeFilter(PRESETS_HISTORY_PBF_FILE, currentDayISO, CURRENT_DAY_FILE);
 
   if (await pbfIsEmpty(CURRENT_DAY_FILE)) {
-    logger(`No data found, skipping ${currentDayISO}`);
+    logger.info(`No data found, skipping ${currentDayISO}`);
     return;
   }
 
-  logger(`Extracting country from current day file...`);
+  logger.info(`Extracting country from current day file...`);
   await extractPoly(
     path.join(POLYFILES_LEVEL_0_DIR, "brazil.poly"),
     CURRENT_DAY_FILE,
@@ -139,7 +139,7 @@ export const update = async (options) => {
   );
 
   // Extract level 1 data
-  logger(`Extracting level 1 data...`);
+  logger.info(`Extracting level 1 data...`);
   await fs.remove(CURRENT_DAY_LEVEL_1_DIR);
   await fs.ensureDir(CURRENT_DAY_LEVEL_1_DIR);
 
@@ -150,7 +150,7 @@ export const update = async (options) => {
   for (let i = 0; i < level1Polyfiles.length; i++) {
     const polyfileName = level1Polyfiles[i];
     const level1AreaId = polyfileName.split(".")[0];
-    logger(`Extracting level 1 area with id: ${level1AreaId}...`);
+    logger.info(`Extracting level 1 area with id: ${level1AreaId}...`);
     await extractPoly(
       path.join(POLYFILES_LEVEL_1_DIR, polyfileName),
       CURRENT_DAY_COUNTRY_FILE,
@@ -159,7 +159,7 @@ export const update = async (options) => {
   }
 
   // Extract level 2 data
-  logger(`Extracting level 2 data...`);
+  logger.info(`Extracting level 2 data...`);
   await fs.remove(CURRENT_DAY_LEVEL_2_DIR);
   await fs.ensureDir(CURRENT_DAY_LEVEL_2_DIR);
 
@@ -184,10 +184,10 @@ export const update = async (options) => {
 
     if (await pbfIsEmpty(level1FilePath)) {
       // Bypass if file is empty
-      logger(`No data found for level 1 area with id: ${level1AreaId}`);
+      logger.verbose(`No data found for level 1 area with id: ${level1AreaId}`);
     } else {
       // Extract level 2 area
-      logger(`Extracting level 2 area with id: ${level2AreaId}...`);
+      logger.verbose(`Extracting level 2 area with id: ${level2AreaId}...`);
       await extractPoly(
         path.join(POLYFILES_LEVEL_2_DIR, polyfileName),
         level1FilePath,
@@ -197,7 +197,7 @@ export const update = async (options) => {
   }
 
   // Extract level 3 data
-  logger(`Extracting level 3 data...`);
+  logger.info(`Extracting level 3 data...`);
   await fs.remove(CURRENT_DAY_LEVEL_3_DIR);
   await fs.ensureDir(CURRENT_DAY_LEVEL_3_DIR);
 
@@ -232,9 +232,9 @@ export const update = async (options) => {
       (await pbfIsEmpty(level2FilePath))
     ) {
       // Bypass if file is empty
-      logger(`No data found for level 2 area with id: ${level2AreaId}`);
+      logger.verbose(`No data found for level 2 area with id: ${level2AreaId}`);
     } else {
-      logger(`Extracting level 3 area with id: ${level3AreaId}...`);
+      logger.verbose(`Extracting level 3 area with id: ${level3AreaId}...`);
       await extractPoly(
         path.join(POLYFILES_LEVEL_3_DIR, polyfileName),
         level2FilePath,
@@ -243,7 +243,7 @@ export const update = async (options) => {
     }
   }
 
-  logger(`Updating GeoJSON files...`);
+  logger.info(`Updating GeoJSON files...`);
   // Clear OSM datasets
   await fs.emptyDir(CURRENT_DAY_PRESETS_DIR);
 

--- a/cli/helpers/curl-download.js
+++ b/cli/helpers/curl-download.js
@@ -1,4 +1,4 @@
-import { execaToStdout } from "./execa.js";
+import exec from "./exec.js";
 
 /**
  *
@@ -19,5 +19,5 @@ export async function curlDownload(
   ]
 ) {
   // Download latest history file to local volume with curl
-  await execaToStdout("curl", [...options, destination, url]);
+  await exec("curl", [...options, destination, url]);
 }

--- a/cli/helpers/exec.js
+++ b/cli/helpers/exec.js
@@ -1,23 +1,15 @@
 import execa from "execa";
 import { logger } from "./logger.js";
 
-export async function execaToStdout(cmd, args) {
+export default async function exec(cmd, args) {
   const execProcess = execa(cmd, args);
 
+  // Log stdout
   execProcess.stdout.on("data", (data) => {
     const lines = data.toString().split("\n");
     lines.forEach((line) => {
       if (line.length > 0) {
         logger.info(line);
-      }
-    });
-  });
-
-  execProcess.stderr.on("data", (data) => {
-    const lines = data.toString().split("\n");
-    lines.forEach((line) => {
-      if (line.length > 0) {
-        logger.error(line);
       }
     });
   });

--- a/cli/helpers/execa.js
+++ b/cli/helpers/execa.js
@@ -1,5 +1,5 @@
 import execa from "execa";
-import { theLogger } from "./logger.js";
+import { logger } from "./logger.js";
 
 export async function execaToStdout(cmd, args) {
   const execProcess = execa(cmd, args);
@@ -8,7 +8,7 @@ export async function execaToStdout(cmd, args) {
     const lines = data.toString().split("\n");
     lines.forEach((line) => {
       if (line.length > 0) {
-        theLogger.info(line);
+        logger.info(line);
       }
     });
   });
@@ -17,7 +17,7 @@ export async function execaToStdout(cmd, args) {
     const lines = data.toString().split("\n");
     lines.forEach((line) => {
       if (line.length > 0) {
-        theLogger.error(line);
+        logger.error(line);
       }
     });
   });

--- a/cli/helpers/execa.js
+++ b/cli/helpers/execa.js
@@ -1,13 +1,26 @@
 import execa from "execa";
+import { theLogger } from "./logger.js";
 
-/**
- * Wrapper function to log execa process to stdout
- * */
-export async function execaToStdout(cmd, args, options) {
+export async function execaToStdout(cmd, args) {
   const execProcess = execa(cmd, args);
-  if (!options || !options.silent) {
-    execProcess.stdout.pipe(process.stdout);
-    execProcess.stderr.pipe(process.stdout);
-  }
+
+  execProcess.stdout.on("data", (data) => {
+    const lines = data.toString().split("\n");
+    lines.forEach((line) => {
+      if (line.length > 0) {
+        theLogger.info(line);
+      }
+    });
+  });
+
+  execProcess.stderr.on("data", (data) => {
+    const lines = data.toString().split("\n");
+    lines.forEach((line) => {
+      if (line.length > 0) {
+        theLogger.error(line);
+      }
+    });
+  });
+
   return execProcess;
 }

--- a/cli/helpers/logger.js
+++ b/cli/helpers/logger.js
@@ -1,13 +1,34 @@
-import pino from "pino";
-const pinoLogger = pino({
-  transport: {
-    target: "pino-pretty",
-  },
+// import pino from "pino";
+// const pinoLogger = pino({
+//   transport: {
+//     target: "pino-pretty",
+//   },
+// });
+
+// // Wrap console.log to avoid lint errors on production code
+// export default function logger(message) {
+//   pinoLogger.info(`-> ${message}`); // eslint-disable-line no-console
+// }
+
+import winston from "winston";
+import "winston-daily-rotate-file";
+import { LOGS_DIR } from "../../config/index.js";
+
+const transport = new winston.transports.DailyRotateFile({
+  filename: "application-%DATE%.log",
+  datePattern: "YYYY-MM-DD-HH",
+  zippedArchive: true,
+  maxSize: "20m",
+  maxFiles: "14d",
+  dirname: LOGS_DIR,
 });
 
-// Wrap console.log to avoid lint errors on production code
+const theLogger = winston.createLogger({
+  transports: [transport],
+});
+
 export default function logger(message) {
-  pinoLogger.info(`-> ${message}`); // eslint-disable-line no-console
+  theLogger.info(`-> ${message}`); // eslint-disable-line no-console
 }
 
 export function time(key) {

--- a/cli/helpers/logger.js
+++ b/cli/helpers/logger.js
@@ -2,7 +2,14 @@ import winston from "winston";
 import "winston-daily-rotate-file";
 import { LOGS_DIR } from "../../config/index.js";
 
-export const theLogger = winston.createLogger({
+const { combine, timestamp, printf, simple } = winston.format;
+
+const logFormat = combine(
+  timestamp(),
+  printf(({ level, message, timestamp }) => `${timestamp} ${level}: ${message}`)
+);
+
+export const logger = winston.createLogger({
   transports: [
     new winston.transports.DailyRotateFile({
       filename: "combined-%DATE%.log",
@@ -11,6 +18,7 @@ export const theLogger = winston.createLogger({
       maxSize: "20m",
       maxFiles: "14d",
       dirname: LOGS_DIR,
+      format: logFormat,
     }),
     new winston.transports.DailyRotateFile({
       filename: "error-%DATE%.log",
@@ -20,16 +28,13 @@ export const theLogger = winston.createLogger({
       maxSize: "20m",
       maxFiles: "14d",
       dirname: LOGS_DIR,
+      format: logFormat,
     }),
     new winston.transports.Console({
-      format: winston.format.simple(),
+      format: simple(),
     }),
   ],
 });
-
-export default function logger(message) {
-  theLogger.info(`-> ${message}`); // eslint-disable-line no-console
-}
 
 export function time(key) {
   console.time(`-> ${key}`); // eslint-disable-line no-console

--- a/cli/helpers/logger.js
+++ b/cli/helpers/logger.js
@@ -1,30 +1,30 @@
-// import pino from "pino";
-// const pinoLogger = pino({
-//   transport: {
-//     target: "pino-pretty",
-//   },
-// });
-
-// // Wrap console.log to avoid lint errors on production code
-// export default function logger(message) {
-//   pinoLogger.info(`-> ${message}`); // eslint-disable-line no-console
-// }
-
 import winston from "winston";
 import "winston-daily-rotate-file";
 import { LOGS_DIR } from "../../config/index.js";
 
-const transport = new winston.transports.DailyRotateFile({
-  filename: "application-%DATE%.log",
-  datePattern: "YYYY-MM-DD-HH",
-  zippedArchive: true,
-  maxSize: "20m",
-  maxFiles: "14d",
-  dirname: LOGS_DIR,
-});
-
-const theLogger = winston.createLogger({
-  transports: [transport],
+export const theLogger = winston.createLogger({
+  transports: [
+    new winston.transports.DailyRotateFile({
+      filename: "combined-%DATE%.log",
+      datePattern: "YYYY-MM-DD",
+      zippedArchive: true,
+      maxSize: "20m",
+      maxFiles: "14d",
+      dirname: LOGS_DIR,
+    }),
+    new winston.transports.DailyRotateFile({
+      filename: "error-%DATE%.log",
+      level: "error",
+      datePattern: "YYYY-MM-DD",
+      zippedArchive: true,
+      maxSize: "20m",
+      maxFiles: "14d",
+      dirname: LOGS_DIR,
+    }),
+    new winston.transports.Console({
+      format: winston.format.simple(),
+    }),
+  ],
 });
 
 export default function logger(message) {

--- a/cli/helpers/logger.js
+++ b/cli/helpers/logger.js
@@ -2,12 +2,7 @@ import winston from "winston";
 import "winston-daily-rotate-file";
 import { LOGS_DIR } from "../../config/index.js";
 
-const { combine, timestamp, printf, simple } = winston.format;
-
-const logFormat = combine(
-  timestamp(),
-  printf(({ level, message, timestamp }) => `${timestamp} ${level}: ${message}`)
-);
+const { printf, simple } = winston.format;
 
 export const logger = winston.createLogger({
   transports: [
@@ -18,7 +13,10 @@ export const logger = winston.createLogger({
       maxSize: "20m",
       maxFiles: "14d",
       dirname: LOGS_DIR,
-      format: logFormat,
+      format: printf(
+        ({ level, message }) =>
+          `${new Date().toISOString()} [${level}] ${message}`
+      ),
     }),
     new winston.transports.DailyRotateFile({
       filename: "error-%DATE%.log",
@@ -28,7 +26,7 @@ export const logger = winston.createLogger({
       maxSize: "20m",
       maxFiles: "14d",
       dirname: LOGS_DIR,
-      format: logFormat,
+      format: printf(({ message }) => `${new Date().toISOString()} ${message}`),
     }),
     new winston.transports.Console({
       format: simple(),

--- a/cli/helpers/osmium.js
+++ b/cli/helpers/osmium.js
@@ -1,5 +1,4 @@
-import execa from "execa";
-import { execaToStdout } from "./execa.js";
+import exec from "./exec.js";
 
 /**
  * Filters a history file by a date.
@@ -9,7 +8,7 @@ import { execaToStdout } from "./execa.js";
  * @param {string} destinationFile File path to destination file
  */
 export async function timeFilter(historyFile, dateIso, destinationFile) {
-  await execaToStdout("osmium", [
+  await exec("osmium", [
     "time-filter",
     historyFile,
     dateIso,
@@ -26,7 +25,7 @@ export async function timeFilter(historyFile, dateIso, destinationFile) {
  * @param {string} currentDayFile File path to current day file
  */
 export async function extract(configFile, currentDayFile) {
-  await execaToStdout(`osmium`, [
+  await exec(`osmium`, [
     `extract`,
     `-v`,
     `-c`,
@@ -43,7 +42,7 @@ export async function extract(configFile, currentDayFile) {
  * @param {string} currentDayFile File path to current day file
  */
 export async function extractPoly(polyfilePath, source, target) {
-  await execaToStdout(`osmium`, [
+  await exec(`osmium`, [
     `extract`,
     `-p`,
     polyfilePath,
@@ -62,7 +61,7 @@ export async function extractPoly(polyfilePath, source, target) {
  * @param {string} outputFile File path to output file
  */
 export async function tagsFilter(inputFile, filters, outputFile) {
-  await execa(`osmium`, [
+  await exec(`osmium`, [
     "tags-filter",
     inputFile,
     "-v",
@@ -72,3 +71,10 @@ export async function tagsFilter(inputFile, filters, outputFile) {
     outputFile,
   ]);
 }
+
+export default {
+  timeFilter,
+  extract,
+  extractPoly,
+  tagsFilter,
+};

--- a/cli/helpers/unzip.js
+++ b/cli/helpers/unzip.js
@@ -1,5 +1,5 @@
-import { execaToStdout } from "./execa.js";
+import exec from "./exec.js";
 
 export async function unzip(file, destination) {
-  await execaToStdout("unzip", ["-o", file, "-d", destination]);
+  await exec("unzip", ["-o", file, "-d", destination]);
 }

--- a/cli/index.js
+++ b/cli/index.js
@@ -87,7 +87,7 @@ program
 
 // Handle errors
 process.on("unhandledRejection", function (error) {
-  logger.error(error);
+  logger.error(JSON.stringify(error, null, 2));
 });
 
 // Parse the arguments

--- a/cli/index.js
+++ b/cli/index.js
@@ -1,7 +1,7 @@
 import "dotenv/config";
 import fs from "fs-extra";
 import { program } from "commander";
-import logger from "./helpers/logger.js";
+import { logger } from "./helpers/logger.js";
 import { fetchFullHistory } from "./fetch-full-history.js";
 import { updatePresetsHistory } from "./update-presets-history.js";
 
@@ -87,7 +87,7 @@ program
 
 // Handle errors
 process.on("unhandledRejection", function (error) {
-  logger(error);
+  logger.error(error);
 });
 
 // Parse the arguments

--- a/cli/index.js
+++ b/cli/index.js
@@ -85,9 +85,22 @@ program
     await context.default(options);
   });
 
-// Handle errors
+/**
+ * Handle unhandled rejections
+ */
 process.on("unhandledRejection", function (error) {
-  logger.error(JSON.stringify(error, null, 2));
+  // Convert error to object, copying its properties
+  const errorOutput = {
+    ...error,
+  };
+
+  // If error is an instance of Error, add stack and name to output
+  if (error instanceof Error) {
+    errorOutput.stack = error.stack;
+    errorOutput.name = error.name;
+  }
+
+  logger.error(JSON.stringify(errorOutput, null, 2));
 });
 
 // Parse the arguments

--- a/cli/update-presets-history.js
+++ b/cli/update-presets-history.js
@@ -13,7 +13,7 @@ import {
   PRESETS_HISTORY_PBF_FILE,
   TMP_DIR,
 } from "../config/index.js";
-import { execaToStdout } from "./helpers/execa.js";
+import exec from "./helpers/exec.js";
 import { curlDownload } from "./helpers/curl-download.js";
 import execa from "execa";
 
@@ -35,7 +35,7 @@ export async function updatePresetsHistoryMetafile(extraMeta = {}) {
   time("Duration of timestamp update");
 
   // Extract metadata from history file
-  const { stdout: firstTimestamp } = await execaToStdout("osmium", [
+  const { stdout: firstTimestamp } = await exec("osmium", [
     "fileinfo",
     "-e",
     "-g",
@@ -43,7 +43,7 @@ export async function updatePresetsHistoryMetafile(extraMeta = {}) {
     PRESETS_HISTORY_PBF_FILE,
   ]);
 
-  const { stdout: lastTimestamp } = await execaToStdout("osmium", [
+  const { stdout: lastTimestamp } = await exec("osmium", [
     "fileinfo",
     "-e",
     "-g",

--- a/cli/update-presets-history.js
+++ b/cli/update-presets-history.js
@@ -7,7 +7,7 @@ import {
   parseISO,
   subDays,
 } from "date-fns";
-import logger, { time, timeEnd } from "./helpers/logger.js";
+import { logger, time, timeEnd } from "./helpers/logger.js";
 import {
   PRESETS_HISTORY_META_JSON,
   PRESETS_HISTORY_PBF_FILE,
@@ -23,7 +23,7 @@ const TMP_HISTORY_DIR = path.join(TMP_DIR, "history");
 const fistDailyChangefileTimestamp = parseISO("2012-09-12T23:59:59.999Z");
 
 export async function updatePresetsHistoryMetafile(extraMeta = {}) {
-  logger("Updating history file timestamp in meta JSON file...");
+  logger.info("Updating history file timestamp in meta JSON file...");
 
   let historyMeta = {};
 
@@ -95,13 +95,13 @@ export async function updatePresetsHistory(options) {
     );
 
     if (historyFileAgeInDays <= 1) {
-      logger("History file is updated.");
+      logger.info("History file is updated.");
       return;
     }
 
     // Check if history file is older than the fist daily changefile
     if (lastDailyUpdate.getTime() < fistDailyChangefileTimestamp.getTime()) {
-      logger(
+      logger.info(
         `History file is older than ${fistDailyChangefileTimestamp.toISOString()}, applying the first daily diff available.`
       );
 
@@ -123,7 +123,7 @@ export async function updatePresetsHistory(options) {
       `${nextDayChangeFileNumber}.osc.gz`
     );
 
-    logger(`Downloading day changefile ${nextDayChangeFileNumber}...`);
+    logger.info(`Downloading day changefile ${nextDayChangeFileNumber}...`);
 
     // Download daily changefile
     try {
@@ -140,7 +140,7 @@ export async function updatePresetsHistory(options) {
       );
       timeEnd("Duration of daily changefile download");
     } catch (error) {
-      logger("Changefile is not available.");
+      logger.info("Changefile is not available.");
       return;
     }
 
@@ -149,7 +149,7 @@ export async function updatePresetsHistory(options) {
       "presets-history.osh.pbf"
     );
 
-    logger(`Applying changes...`);
+    logger.info(`Applying changes...`);
     time("Duration of daily change apply operation");
     await execa("osmium", [
       "apply-changes",
@@ -160,23 +160,23 @@ export async function updatePresetsHistory(options) {
     ]);
     timeEnd("Duration of daily change apply operation");
 
-    logger(`Replacing current file...`);
+    logger.info(`Replacing current file...`);
     await fs.move(UPDATED_PRESETS_HISTORY_FILE, PRESETS_HISTORY_PBF_FILE, {
       overwrite: true,
     });
 
     await updatePresetsHistoryMetafile();
-    logger(`Finished!`);
+    logger.info(`Finished!`);
 
     await fs.remove(dailyChangeFile);
 
     timeEnd("Daily update total duration");
 
     if (options && options.recursive) {
-      logger("Replicating history file...");
+      logger.info("Replicating history file...");
       await updatePresetsHistory(options);
     }
   } catch (error) {
-    logger(error);
+    logger.error(error);
   }
 }

--- a/config/index.js
+++ b/config/index.js
@@ -12,6 +12,14 @@ const basePath = path.resolve();
 export const CLI_APP_DIR = path.join(basePath, "cli");
 
 /**
+ * LOGS DIRECTORY
+ */
+export const LOGS_DIR = path.join(
+  process.env.LOGS_DIR || path.join(basePath, "app-data", "logs"),
+  NODE_ENV
+);
+
+/**
  * Path to the data directory used by the CLI to store data
  * (e.g. downloaded files, local git repository, etc)
  *

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "knex": "^2.4.2",
     "osmtogeojson": "^3.0.0-beta.4",
     "pg": "^8.7.3",
-    "pino": "^8.14.1",
-    "pino-pretty": "^10.0.0"
+    "winston": "^3.9.0",
+    "winston-daily-rotate-file": "^4.7.1"
   },
   "devDependencies": {
     "@fast-csv/parse": "^4.3.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,20 @@
 # yarn lockfile v1
 
 
+"@colors/colors@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@colors/colors/-/colors-1.5.0.tgz#bb504579c1cae923e6576a4f5da43d25f97bdbd9"
+  integrity sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==
+
+"@dabh/diagnostics@^2.0.2":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@dabh/diagnostics/-/diagnostics-2.0.3.tgz#7f7e97ee9a725dffc7808d93668cc984e1dc477a"
+  integrity sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==
+  dependencies:
+    colorspace "1.1.x"
+    enabled "2.0.x"
+    kuler "^2.0.0"
+
 "@eslint/eslintrc@^1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.0.tgz#29f92c30bb3e771e4a2048c95fa6855392dfac4f"
@@ -114,6 +128,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.24.tgz#406b220dc748947e1959d8a38a75979e87166704"
   integrity sha512-aJdn8XErcSrfr7k8ZDDfU6/2OgjZcB2Fu9d+ESK8D7Oa5mtsv8Fa8GpcwTA0v60kuZBaalKPzuzun4Ov1YWO/w==
 
+"@types/triple-beam@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@types/triple-beam/-/triple-beam-1.3.2.tgz#38ecb64f01aa0d02b7c8f4222d7c38af6316fef8"
+  integrity sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g==
+
 JSONStream@0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-0.8.0.tgz#efc462d5a5bc94ec007f4b22571acd7f6f2ae013"
@@ -213,6 +232,11 @@ async@^2.6.4:
   integrity sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==
   dependencies:
     lodash "^4.17.14"
+
+async@^3.2.3:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
+  integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
 
 atomic-sleep@^1.0.0:
   version "1.0.0"
@@ -319,6 +343,13 @@ cli-progress@^3.11.2:
   dependencies:
     string-width "^4.2.3"
 
+color-convert@^1.9.3:
+  version "1.9.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
+  integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
+  dependencies:
+    color-name "1.1.3"
+
 color-convert@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
@@ -326,10 +357,31 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
-color-name@~1.1.4:
+color-name@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+  integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
+
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.6.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
+  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
+color@^3.1.3:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.2.1.tgz#3544dc198caf4490c3ecc9a790b54fe9ff45e164"
+  integrity sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==
+  dependencies:
+    color-convert "^1.9.3"
+    color-string "^1.6.0"
 
 colorette@2.0.19:
   version "2.0.19"
@@ -340,6 +392,14 @@ colorette@^2.0.7:
   version "2.0.20"
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
+
+colorspace@1.1.x:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/colorspace/-/colorspace-1.1.4.tgz#8d442d1186152f60453bf8070cd66eb364e59243"
+  integrity sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==
+  dependencies:
+    color "^3.1.3"
+    text-hex "1.0.x"
 
 commander@^9.1.0, commander@^9.4.0:
   version "9.4.0"
@@ -488,6 +548,11 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+enabled@2.0.x:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/enabled/-/enabled-2.0.0.tgz#f9dd92ec2d6f4bbc0d5d1e64e21d61cd4665e7c2"
+  integrity sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==
 
 end-of-stream@^1.1.0:
   version "1.4.4"
@@ -840,6 +905,11 @@ fastq@^1.6.0:
   dependencies:
     reusify "^1.0.4"
 
+fecha@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.3.tgz#4d9ccdbc61e8629b259fdca67e65891448d569fd"
+  integrity sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==
+
 fetch-blob@^3.1.2, fetch-blob@^3.1.4:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
@@ -854,6 +924,13 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
+
+file-stream-rotator@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/file-stream-rotator/-/file-stream-rotator-0.6.1.tgz#007019e735b262bb6c6f0197e58e5c87cb96cec3"
+  integrity sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ==
+  dependencies:
+    moment "^2.29.1"
 
 fill-range@^7.0.1:
   version "7.0.1"
@@ -882,6 +959,11 @@ flatted@^3.1.0:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.6.tgz#022e9218c637f9f3fc9c35ab9c9193f05add60b2"
   integrity sha512-0sQoMh9s0BYsm+12Huy/rkKxVu4R1+r96YX5cG44rHV0pQ6iC3Q+mkoMFaGWObMFYQxCVT+ssG1ksneA2MI9KQ==
+
+fn.name@1.x.x:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
+  integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
 follow-redirects@^1.0.0:
   version "1.15.1"
@@ -1196,6 +1278,11 @@ interpret@^2.2.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
+
 is-bigint@^1.0.1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.4.tgz#08147a1875bc2b32005d41ccd8291dffc6691df3"
@@ -1396,6 +1483,11 @@ knex@^2.4.2:
     tarn "^3.0.2"
     tildify "2.0.0"
 
+kuler@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/kuler/-/kuler-2.0.0.tgz#e2c570a3800388fb44407e851531c1d670b061b3"
+  integrity sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==
+
 levn@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.4.1.tgz#ae4562c007473b932a6200d403268dd2fffc6ade"
@@ -1450,6 +1542,18 @@ lodash@^4.17.14, lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+logform@^2.3.2, logform@^2.4.0:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/logform/-/logform-2.5.1.tgz#44c77c34becd71b3a42a3970c77929e52c6ed48b"
+  integrity sha512-9FyqAm9o9NKKfiAKfZoYo9bGXXuwMkxQiQttkT4YjjVtQVIQtK6LmVtlxmCaFswo6N4AfEkHqZTV0taDtPotNg==
+  dependencies:
+    "@colors/colors" "1.5.0"
+    "@types/triple-beam" "^1.3.2"
+    fecha "^4.2.0"
+    ms "^2.1.1"
+    safe-stable-stringify "^2.3.1"
+    triple-beam "^1.3.0"
 
 loose-envify@^1.4.0:
   version "1.4.0"
@@ -1529,6 +1633,11 @@ mkdirp@^0.5.6:
   dependencies:
     minimist "^1.2.6"
 
+moment@^2.29.1:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -1574,6 +1683,11 @@ object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
+
+object-hash@^2.0.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.2.0.tgz#5ad518581eefc443bd763472b8ff2e9c2c0d54a5"
+  integrity sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==
 
 object-inspect@^1.12.0, object-inspect@^1.9.0:
   version "1.12.2"
@@ -1641,6 +1755,13 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
   dependencies:
     wrappy "1"
+
+one-time@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/one-time/-/one-time-1.0.0.tgz#e06bc174aed214ed58edede573b433bbf827cb45"
+  integrity sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==
+  dependencies:
+    fn.name "1.x.x"
 
 onetime@^5.1.2:
   version "5.1.2"
@@ -1999,7 +2120,7 @@ readable-stream@^3.0.2:
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-readable-stream@^3.6.0:
+readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.2.tgz#56a9b36ea965c00c5a93ef31eb111a0f11056967"
   integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
@@ -2196,6 +2317,13 @@ simple-git@^3.12.0:
     "@kwsites/promise-deferred" "^1.1.1"
     debug "^4.3.4"
 
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==
+  dependencies:
+    is-arrayish "^0.3.1"
+
 slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
@@ -2224,6 +2352,11 @@ split@~0.2.10:
   integrity sha512-e0pKq+UUH2Xq/sXbYpZBZc3BawsfDZ7dgv+JtRTUPNcvF5CMR4Y9cvJqkMY0MoxWzTHvZuz1beg6pNEKlszPiQ==
   dependencies:
     through "2"
+
+stack-trace@0.0.x:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+  integrity sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==
 
 string-width@^4.2.3:
   version "4.2.3"
@@ -2324,6 +2457,11 @@ tarn@^3.0.2:
   resolved "https://registry.yarnpkg.com/tarn/-/tarn-3.0.2.tgz#73b6140fbb881b71559c4f8bfde3d9a4b3d27693"
   integrity sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==
 
+text-hex@1.0.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/text-hex/-/text-hex-1.0.0.tgz#69dc9c1b17446ee79a92bf5b884bb4b9127506f5"
+  integrity sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -2370,6 +2508,11 @@ to-regex-range@^5.0.1:
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+triple-beam@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.3.0.tgz#a595214c7298db8339eeeee083e4d10bd8cb8dd9"
+  integrity sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==
 
 tsconfig-paths@^3.14.1:
   version "3.14.1"
@@ -2476,6 +2619,42 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+winston-daily-rotate-file@^4.7.1:
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/winston-daily-rotate-file/-/winston-daily-rotate-file-4.7.1.tgz#f60a643af87f8867f23170d8cd87dbe3603a625f"
+  integrity sha512-7LGPiYGBPNyGHLn9z33i96zx/bd71pjBn9tqQzO3I4Tayv94WPmBNwKC7CO1wPHdP9uvu+Md/1nr6VSH9h0iaA==
+  dependencies:
+    file-stream-rotator "^0.6.1"
+    object-hash "^2.0.1"
+    triple-beam "^1.3.0"
+    winston-transport "^4.4.0"
+
+winston-transport@^4.4.0, winston-transport@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.5.0.tgz#6e7b0dd04d393171ed5e4e4905db265f7ab384fa"
+  integrity sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==
+  dependencies:
+    logform "^2.3.2"
+    readable-stream "^3.6.0"
+    triple-beam "^1.3.0"
+
+winston@^3.9.0:
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.9.0.tgz#2bbdeb8167a75fac6d9a0c6d002890cd908016c2"
+  integrity sha512-jW51iW/X95BCW6MMtZWr2jKQBP4hV5bIDq9QrIjfDk6Q9QuxvTKEAlpUNAzP+HYHFFCeENhph16s0zEunu4uuQ==
+  dependencies:
+    "@colors/colors" "1.5.0"
+    "@dabh/diagnostics" "^2.0.2"
+    async "^3.2.3"
+    is-stream "^2.0.0"
+    logform "^2.4.0"
+    one-time "^1.0.0"
+    readable-stream "^3.4.0"
+    safe-stable-stringify "^2.3.1"
+    stack-trace "0.0.x"
+    triple-beam "^1.3.0"
+    winston-transport "^4.5.0"
 
 word-wrap@^1.2.3:
   version "1.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -141,13 +141,6 @@ JSONStream@0.8.0:
     jsonparse "0.0.5"
     through "~2.2.7"
 
-abort-controller@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
-  integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
-  dependencies:
-    event-target-shim "^5.0.0"
-
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
@@ -238,20 +231,10 @@ async@^3.2.3:
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
   integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
 
-atomic-sleep@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/atomic-sleep/-/atomic-sleep-1.0.0.tgz#eb85b77a601fc932cfe432c5acd364a9e2c9075b"
-  integrity sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==
-
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
-
-base64-js@^1.3.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
-  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
 basic-auth@^2.0.1:
   version "2.0.1"
@@ -267,13 +250,6 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
-
-brace-expansion@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
-  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
-  dependencies:
-    balanced-match "^1.0.0"
 
 braces@^3.0.2:
   version "3.0.2"
@@ -291,14 +267,6 @@ buffer-writer@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/buffer-writer/-/buffer-writer-2.0.0.tgz#ce7eb81a38f7829db09c873f2fbb792c0c98ec04"
   integrity sha512-a7ZpuTZU1TRtnwyCNW3I5dc0wWNC3VR9S++Ewyk2HHZdrO3CQJqSpd+95Us590V6AL7JqUAH2IwZ/398PmNFgw==
-
-buffer@^6.0.3:
-  version "6.0.3"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
-  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
-  dependencies:
-    base64-js "^1.3.1"
-    ieee754 "^1.2.1"
 
 builtins@^5.0.1:
   version "5.0.1"
@@ -388,11 +356,6 @@ colorette@2.0.19:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
   integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
 
-colorette@^2.0.7:
-  version "2.0.20"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
-  integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
-
 colorspace@1.1.x:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/colorspace/-/colorspace-1.1.4.tgz#8d442d1186152f60453bf8070cd66eb364e59243"
@@ -459,11 +422,6 @@ date-fns@^2.29.3:
   version "2.29.3"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
   integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
-
-dateformat@^4.6.3:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-4.6.3.tgz#556fa6497e5217fedb78821424f8a1c22fa3f4b5"
-  integrity sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==
 
 debug@4.3.4, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
@@ -553,13 +511,6 @@ enabled@2.0.x:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/enabled/-/enabled-2.0.0.tgz#f9dd92ec2d6f4bbc0d5d1e64e21d61cd4665e7c2"
   integrity sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==
-
-end-of-stream@^1.1.0:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
-  integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
-  dependencies:
-    once "^1.4.0"
 
 es-abstract@^1.19.0, es-abstract@^1.19.1, es-abstract@^1.19.2, es-abstract@^1.19.5:
   version "1.20.1"
@@ -827,20 +778,10 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-event-target-shim@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/event-target-shim/-/event-target-shim-5.0.1.tgz#5d4d3ebdf9583d63a5333ce2deb7480ab2b05789"
-  integrity sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==
-
 eventemitter3@^4.0.0:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
-
-events@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
-  integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
 
 execa@^5.1.1:
   version "5.1.1"
@@ -856,11 +797,6 @@ execa@^5.1.1:
     onetime "^5.1.2"
     signal-exit "^3.0.3"
     strip-final-newline "^2.0.0"
-
-fast-copy@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/fast-copy/-/fast-copy-3.0.1.tgz#9e89ef498b8c04c1cd76b33b8e14271658a732aa"
-  integrity sha512-Knr7NOtK3HWRYGtHoJrjkaWepqT8thIVGAwt0p0aUs1zqkAzXZV4vo9fFNwyb5fcqK1GKYFYxldQdIDVKhUAfA==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -887,16 +823,6 @@ fast-levenshtein@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
-
-fast-redact@^3.1.1:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/fast-redact/-/fast-redact-3.2.0.tgz#b1e2d39bc731376d28bde844454fa23e26919987"
-  integrity sha512-zaTadChr+NekyzallAMXATXLOR8MNx3zqpZ0MUF2aGf4EathnG0f32VLODNlY8IuGY3HoRO2L6/6fSzNsLaHIw==
-
-fast-safe-stringify@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz#c406a83b6e70d9e35ce3b30a81141df30aeba884"
-  integrity sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==
 
 fastq@^1.6.0:
   version "1.13.0"
@@ -1082,17 +1008,6 @@ glob@^7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^8.0.0:
-  version "8.1.0"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-8.1.0.tgz#d388f656593ef708ee3e34640fdfb99a9fd1c33e"
-  integrity sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^5.0.1"
-    once "^1.3.0"
-
 globals@^13.15.0:
   version "13.17.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-13.17.0.tgz#902eb1e680a41da93945adbdcb5a9f361ba69bd4"
@@ -1163,14 +1078,6 @@ he@^1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-help-me@^4.0.1:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/help-me/-/help-me-4.2.0.tgz#50712bfd799ff1854ae1d312c36eafcea85b0563"
-  integrity sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==
-  dependencies:
-    glob "^8.0.0"
-    readable-stream "^3.6.0"
-
 html-encoding-sniffer@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz#2cb1a8cf0db52414776e5b2a7a04d5dd98158de9"
@@ -1228,7 +1135,7 @@ iconv-lite@0.6.3:
   dependencies:
     safer-buffer ">= 2.1.2 < 3.0.0"
 
-ieee754@^1.1.12, ieee754@^1.2.1:
+ieee754@^1.1.12:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -1406,11 +1313,6 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
-
-joycon@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/joycon/-/joycon-3.1.1.tgz#bce8596d6ae808f8b68168f5fc69280996894f03"
-  integrity sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==
 
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"
@@ -1604,13 +1506,6 @@ minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^5.0.1:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
-  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
-  dependencies:
-    brace-expansion "^2.0.1"
-
 minimist@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.5.tgz#d7aa327bcecf518f9106ac6b8f003fa3bcea8566"
@@ -1744,12 +1639,7 @@ object.values@^1.1.5:
     define-properties "^1.1.3"
     es-abstract "^1.19.1"
 
-on-exit-leak-free@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/on-exit-leak-free/-/on-exit-leak-free-2.1.0.tgz#5c703c968f7e7f851885f6459bf8a8a57edc9cc4"
-  integrity sha512-VuCaZZAjReZ3vUwgOB8LxAosIurDiAW0s13rI1YwmaP++jvcxP77AWoQvenZebpCA2m8WC1/EosPYPMjnRAp/w==
-
-once@^1.3.0, once@^1.3.1, once@^1.4.0:
+once@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
@@ -1938,56 +1828,6 @@ picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-pino-abstract-transport@^1.0.0, pino-abstract-transport@v1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/pino-abstract-transport/-/pino-abstract-transport-1.0.0.tgz#cc0d6955fffcadb91b7b49ef220a6cc111d48bb3"
-  integrity sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==
-  dependencies:
-    readable-stream "^4.0.0"
-    split2 "^4.0.0"
-
-pino-pretty@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/pino-pretty/-/pino-pretty-10.0.0.tgz#fd2f307ee897289f63d09b0b804ac2ecc9a18516"
-  integrity sha512-zKFjYXBzLaLTEAN1ayKpHXtL5UeRQC7R3lvhKe7fWs7hIVEjKGG/qIXwQt9HmeUp71ogUd/YcW+LmMwRp4KT6Q==
-  dependencies:
-    colorette "^2.0.7"
-    dateformat "^4.6.3"
-    fast-copy "^3.0.0"
-    fast-safe-stringify "^2.1.1"
-    help-me "^4.0.1"
-    joycon "^3.1.1"
-    minimist "^1.2.6"
-    on-exit-leak-free "^2.1.0"
-    pino-abstract-transport "^1.0.0"
-    pump "^3.0.0"
-    readable-stream "^4.0.0"
-    secure-json-parse "^2.4.0"
-    sonic-boom "^3.0.0"
-    strip-json-comments "^3.1.1"
-
-pino-std-serializers@^6.0.0:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/pino-std-serializers/-/pino-std-serializers-6.2.1.tgz#369f4ae2a19eb6d769ddf2c88a2164b76879a284"
-  integrity sha512-wHuWB+CvSVb2XqXM0W/WOYUkVSPbiJb9S5fNB7TBhd8s892Xq910bRxwHtC4l71hgztObTjXL6ZheZXFjhDrDQ==
-
-pino@^8.14.1:
-  version "8.14.1"
-  resolved "https://registry.yarnpkg.com/pino/-/pino-8.14.1.tgz#bb38dcda8b500dd90c1193b6c9171eb777a47ac8"
-  integrity sha512-8LYNv7BKWXSfS+k6oEc6occy5La+q2sPwU3q2ljTX5AZk7v+5kND2o5W794FyRaqha6DJajmkNRsWtPpFyMUdw==
-  dependencies:
-    atomic-sleep "^1.0.0"
-    fast-redact "^3.1.1"
-    on-exit-leak-free "^2.1.0"
-    pino-abstract-transport v1.0.0
-    pino-std-serializers "^6.0.0"
-    process-warning "^2.0.0"
-    quick-format-unescaped "^4.0.3"
-    real-require "^0.2.0"
-    safe-stable-stringify "^2.3.1"
-    sonic-boom "^3.1.0"
-    thread-stream "^2.0.0"
-
 portfinder@^1.0.28:
   version "1.0.32"
   resolved "https://registry.yarnpkg.com/portfinder/-/portfinder-1.0.32.tgz#2fe1b9e58389712429dc2bea5beb2146146c7f81"
@@ -2029,16 +1869,6 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-process-warning@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/process-warning/-/process-warning-2.2.0.tgz#008ec76b579820a8e5c35d81960525ca64feb626"
-  integrity sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg==
-
-process@^0.11.10:
-  version "0.11.10"
-  resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
-  integrity sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==
-
 prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
@@ -2052,14 +1882,6 @@ protocol-buffers-schema@^3.3.1:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz#77bc75a48b2ff142c1ad5b5b90c94cd0fa2efd03"
   integrity sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==
-
-pump@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/pump/-/pump-3.0.0.tgz#b4a2116815bde2f4e1ea602354e8c75565107a64"
-  integrity sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
-  dependencies:
-    end-of-stream "^1.1.0"
-    once "^1.3.1"
 
 punycode@^2.1.0:
   version "2.1.1"
@@ -2077,11 +1899,6 @@ queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.3.tgz#4929228bbc724dfac43e0efb058caf7b6cfb6243"
   integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
-
-quick-format-unescaped@^4.0.3:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz#93ef6dd8d3453cbc7970dd614fad4c5954d6b5a7"
-  integrity sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==
 
 react-is@^16.13.1:
   version "16.13.1"
@@ -2128,21 +1945,6 @@ readable-stream@^3.4.0, readable-stream@^3.6.0:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
-
-readable-stream@^4.0.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-4.4.0.tgz#55ce132d60a988c460d75c631e9ccf6a7229b468"
-  integrity sha512-kDMOq0qLtxV9f/SQv522h8cxZBqNZXuXNyjyezmfAAuribMyVXziljpQ/uQhfE1XLg2/TLTW2DsnoE4VAi/krg==
-  dependencies:
-    abort-controller "^3.0.0"
-    buffer "^6.0.3"
-    events "^3.3.0"
-    process "^0.11.10"
-
-real-require@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/real-require/-/real-require-0.2.0.tgz#209632dea1810be2ae063a6ac084fee7e33fba78"
-  integrity sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==
 
 rechoir@^0.8.0:
   version "0.8.0"
@@ -2256,11 +2058,6 @@ secure-compare@3.0.1:
   resolved "https://registry.yarnpkg.com/secure-compare/-/secure-compare-3.0.1.tgz#f1a0329b308b221fae37b9974f3d578d0ca999e3"
   integrity sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==
 
-secure-json-parse@^2.4.0:
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/secure-json-parse/-/secure-json-parse-2.7.0.tgz#5a5f9cd6ae47df23dba3151edd06855d47e09862"
-  integrity sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==
-
 semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
@@ -2328,18 +2125,6 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
-
-sonic-boom@^3.0.0, sonic-boom@^3.1.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/sonic-boom/-/sonic-boom-3.3.0.tgz#cffab6dafee3b2bcb88d08d589394198bee1838c"
-  integrity sha512-LYxp34KlZ1a2Jb8ZQgFCK3niIHzibdwtwNUWKg0qQRzsDoJ3Gfgkf8KdBTFU3SkejDEIlWwnSnpVdOZIhFMl/g==
-  dependencies:
-    atomic-sleep "^1.0.0"
-
-split2@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/split2/-/split2-4.2.0.tgz#c9c5920904d148bab0b9f67145f245a86aadbfa4"
-  integrity sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==
 
 split2@^4.1.0:
   version "4.1.0"
@@ -2466,13 +2251,6 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
-
-thread-stream@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/thread-stream/-/thread-stream-2.3.0.tgz#4fc07fb39eff32ae7bad803cb7dd9598349fed33"
-  integrity sha512-kaDqm1DET9pp3NXwR8382WHbnpXnRkN9xGN9dQt3B2+dmXiW8X1SOwmFOxAErEQ47ObhZ96J6yhZNXuyCOL7KA==
-  dependencies:
-    real-require "^0.2.0"
 
 through@2:
   version "2.3.8"


### PR DESCRIPTION
This contributes to #8 and will help debug issues in staging in production as it centralizes logging into the shared volume. Currently,  logs are deleted after the pods are finished.

Changes added:

- Replaces Pino with Winston, which has a really nice extension for generating daily rotated log files
- Added correct log levels to function calls
- Renamed helper `execa` to `exec` to avoid confusion with `execa` module

 To test, make sure your `.env` is pointing to a local install and try running all the commands like setup context, download full history, etc. Inspect the app data dir, it should include logs files at `app-data/logs/<environment>`.

@Rub21 this is ready for review. Please let me know if you have any questions.